### PR TITLE
http post error 

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,11 +38,18 @@ local reqfunc = (syn or http).request;
 local libtype = syn and "syn" or "http";
 local hooked = {};
 local proxied = {};
+
+local function hasHttpPost()
+    return pcall(function()
+        return game.HttpPost
+    end) and true or nil;
+end;
+
 local methods = {
     HttpGet = not syn,
     HttpGetAsync = not syn,
     GetObjects = true,
-    HttpPost = not syn,
+    HttpPost = hasHttpPost(),
     HttpPostAsync = not syn
 }
 


### PR DESCRIPTION
some executors dont support httppost, causing the http spy to error, thus i wrote a quick fix for it which adds proper checking for the availability of httppost.